### PR TITLE
Use param for monitoring server host address

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,8 @@ zbx_server_ssl_certificate_path: '{{ zbx_server_ssl_certificate_key_prefix}}/zab
 zbx_server_ssl_certificate_key_path: '{{ zbx_server_ssl_certificate_key_prefix}}/zabbix_server.key'
 
 # monitoring master server host in inventry.
-zbx_monitoring_server_host: '{{ hostvars[monitoring_server]["ansible_%s"|format(zbx_monitoring_eth_number)]["ipv4"]["address"] }}'
+zbx_monitoring_server: ''
+zbx_monitoring_server_host: '{{ hostvars[zbx_monitoring_server]["ansible_%s"|format(zbx_monitoring_eth_number)]["ipv4"]["address"] }}'
 zbx_monitoring_eth_number: 'eth0'
 
 zbx_server_db_user: zabbix

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,7 +10,7 @@ zbx_server_ssl_certificate_path: '{{ zbx_server_ssl_certificate_key_prefix}}/zab
 zbx_server_ssl_certificate_key_path: '{{ zbx_server_ssl_certificate_key_prefix}}/zabbix_server.key'
 
 # monitoring master server host in inventry.
-zbx_monitoring_serverhost: ''
+zbx_monitoring_server_host: '{{ hostvars[monitoring_server]["ansible_%s"|format(zbx_monitoring_eth_number)]["ipv4"]["address"] }}'
 zbx_monitoring_eth_number: 'eth0'
 
 zbx_server_db_user: zabbix

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -5,9 +5,9 @@
   include: repository.yml
 
 - include: zabbix_server/main.yml
-  when: monitoring_master
+  when: zbx_server
   tags:
-    - monitoring_master
+    - zbx_server
 
 - include: zabbix_agent/main.yml
   tags:

--- a/tasks/zabbix_server/package.yml
+++ b/tasks/zabbix_server/package.yml
@@ -1,5 +1,5 @@
 - name: install zabbix server packages
-  when: monitoring_master
+  when: zbx_server
   apt:
     name={{ item }}
     state=present

--- a/templates/etc/zabbix/web/zabbix.conf.php.j2
+++ b/templates/etc/zabbix/web/zabbix.conf.php.j2
@@ -12,7 +12,7 @@ $DB['PASSWORD'] = '{{ zbx_server_db_password }}';
 // Schema name. Used for IBM DB2 and PostgreSQL.
 $DB['SCHEMA'] = '';
 
-$ZBX_SERVER      = '{{ hostvars[monitoring_server]['ansible_%s'|format(zbx_monitoring_eth_number)]['ipv4']['address'] }}';
+$ZBX_SERVER      = '{{ zbx_monitoring_server_host }}';
 $ZBX_SERVER_PORT = '10051';
 $ZBX_SERVER_NAME = '';
 

--- a/templates/etc/zabbix/zabbix_agentd.conf.j2
+++ b/templates/etc/zabbix/zabbix_agentd.conf.j2
@@ -95,7 +95,7 @@ LogFileSize=0
 {% if 'monitoring' in group_names %}
 Server=127.0.0.1
 {% else %}
-Server={{ hostvars[monitoring_server]['ansible_%s'|format(zbx_monitoring_eth_number)]['ipv4']['address'] }}
+Server={{ zbx_monitoring_server_host }}
 {% endif %}
 
 ### Option: ListenPort
@@ -140,7 +140,7 @@ Server={{ hostvars[monitoring_server]['ansible_%s'|format(zbx_monitoring_eth_num
 {% if 'monitoring' in group_names %}
 ServerActive=127.0.0.1
 {% else %}
-ServerActive={{ hostvars[monitoring_server]['ansible_%s'|format(zbx_monitoring_eth_number)]['ipv4']['address'] }}
+ServerActive={{ zbx_monitoring_server_host }}
 {% endif %}
 
 


### PR DESCRIPTION
- `zbx_monitoring_server_host` : zabbix hosting server FQDN or IPaddr.
- delete `monitoring_server`
